### PR TITLE
UI/UX: product vision alignment, mobile polish, home filter debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,29 @@
 ```bash
 npm install
 cp .env.example .env   # 編集: DATABASE_URL（Neon 等の postgresql://…）、NEXTAUTH_*、GOOGLE_*
-npm run db:push         # 初回のみ（リモート DB にスキーマ反映）
-# 任意: サンプル部屋・フォロー・いいね等を入れる（開発 DB のみ。既存 User はすべて削除されます）
-# npm run db:seed
+npm run db:push         # 初回のみ（リモート DB にスキーマ反映）。マイグレーション運用なら下記シード節を参照
 npm run dev
 ```
 
 Git で無視するファイル・DB の扱いは [`docs/git-and-local-data.md`](docs/git-and-local-data.md) を参照。
+
+### サンプルデータ（シード）
+
+[`prisma/seed.ts`](prisma/seed.ts) で **ユーザー 3 名・投稿・フォロー・いいね・保存・欲しい** を投入します。**実行すると既存の `User` はすべて削除**され、関連データは Cascade で消えます。本番で実ユーザーを抱えた DB では **絶対に実行しない**でください。
+
+**手順（Neon などリモート含む）**
+
+1. `.env` の `DATABASE_URL` を対象 DB に向ける  
+2. スキーマを最新にする: `npx prisma migrate deploy`  
+3. シード: `npm run db:seed`（内部で `npx prisma db seed` → `tsx prisma/seed.ts`）
+
+まとめて実行する場合:
+
+```bash
+npm run db:migrate-and-seed
+```
+
+画像 URL は Unsplash（[`next.config.mjs`](next.config.mjs) の `remotePatterns` 済み）。シードのメール（`seed-*@nook.example`）は **Google ログインではそのまま使えない**ことが多いですが、**未ログインでも**ホーム・部屋詳細・プロフィールの表示確認に使えます。
 
 ブラウザで http://localhost:3001 を開く（`package.json` の dev ポート）。
 
@@ -62,8 +78,9 @@ Git で無視するファイル・DB の扱いは [`docs/git-and-local-data.md`]
 | `npm run build` | 本番ビルド（`prisma generate` → `next build`） |
 | `npm run start` | 本番サーバー |
 | `npm run lint` | ESLint（Flat Config: [`eslint.config.mjs`](eslint.config.mjs)） |
-| `npm run db:push` | DB スキーマ反映 |
+| `npm run db:push` | DB スキーマ反映（マイグレーション未使用の開発向け） |
 | `npm run db:seed` | 開発用シード（**全ユーザーを削除**してから投入。[`prisma/seed.ts`](prisma/seed.ts)） |
+| `npm run db:migrate-and-seed` | `migrate deploy` のあと `db:seed`（空の Neon などに一括） |
 
 ## 技術スタック（主要パッケージ）
 
@@ -89,6 +106,8 @@ Git で無視するファイル・DB の扱いは [`docs/git-and-local-data.md`]
 ## 本番デプロイ
 
 - **DB**: **Neon**（または Vercel Postgres 等）の接続文字列を環境変数に設定
+- **マイグレーション**: 初回・更新時に `npx prisma migrate deploy`（本番パイプラインまたは手元から `DATABASE_URL` 指定）
 - **画像**: Cloudinary 推奨（`.env` に `CLOUDINARY_*`）
 - **NEXTAUTH_URL**: 本番 URL（OG の `metadataBase` にも利用）
 - **Google OAuth**: 本番ドメインをリダイレクト URI に追加
+- **シード**: ステージング用の空 DB など **限定的な用途**でのみ `npm run db:migrate-and-seed` を検討（手順は上記「サンプルデータ（シード）」）。**実ユーザーのいる本番 DB では実行しない**

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint .",
     "postinstall": "npx prisma generate",
     "db:push": "npx prisma db push",
-    "db:seed": "npx prisma db seed"
+    "db:seed": "npx prisma db seed",
+    "db:migrate-and-seed": "npx prisma migrate deploy && npx prisma db seed"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.2",

--- a/prisma/migrations/20260322120000_furniture_brand_pins_wishlist_rank/migration.sql
+++ b/prisma/migrations/20260322120000_furniture_brand_pins_wishlist_rank/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "FurnitureItem" ADD COLUMN "brand" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "FurnitureItem" ADD COLUMN "brandSlug" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "FurnitureItem" ADD COLUMN "pinX" DOUBLE PRECISION;
+ALTER TABLE "FurnitureItem" ADD COLUMN "pinY" DOUBLE PRECISION;
+
+-- AlterTable
+ALTER TABLE "ItemWishlist" ADD COLUMN "buyRank" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE INDEX "FurnitureItem_brandSlug_idx" ON "FurnitureItem"("brandSlug");

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,6 +3,7 @@
  * 本番 DB では実行しないでください。
  *
  * 画像・プロフィール写真は next.config の remotePatterns に含まれる Unsplash の URL を使用。
+ * （Unsplash 側で写真が削除されると 404 になるため、表示できないときは URL を差し替えてください。）
  * ログインは Google OAuth のため、シードのメールでそのままログインできるとは限りません。
  * 未ログインでもホーム・部屋詳細・プロフィールの表示確認に使えます。
  */
@@ -19,6 +20,10 @@ const IMG = {
   kitchen: "https://images.unsplash.com/photo-1556911220-bff31c812dba?auto=format&fit=crop&w=1200&q=80",
   oneroom: "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
   plants: "https://images.unsplash.com/photo-1416879595882-3373a0480b5b?auto=format&fit=crop&w=1200&q=80",
+  dining: "https://images.unsplash.com/photo-1617806118233-18e1de247200?auto=format&fit=crop&w=1200&q=80",
+  hallway: "https://images.unsplash.com/photo-1600607687939-ce8a6c25118c?auto=format&fit=crop&w=1200&q=80",
+  bookshelf:
+    "https://images.unsplash.com/photo-1507842217343-583bb7270b66?auto=format&fit=crop&w=1200&q=80",
 } as const;
 
 /** プロフィールアイコン（next.config の Unsplash のみ） */
@@ -27,6 +32,7 @@ const AVATAR = {
     "https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=crop&w=256&h=256&q=80",
   kota: "https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?auto=format&fit=crop&w=256&h=256&q=80",
   mina: "https://images.unsplash.com/photo-1534528741775-53994a69daeb?auto=format&fit=crop&w=256&h=256&q=80",
+  ren: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&w=256&h=256&q=80",
 } as const;
 
 function createPrisma(): PrismaClient {
@@ -78,11 +84,28 @@ async function main() {
     },
   });
 
+  const ren = await prisma.user.create({
+    data: {
+      id: "seed_user_ren",
+      name: "レン",
+      email: "seed-ren@nook.example",
+      image: AVATAR.ren,
+      bio: "2LDK・ダイニング中心に過ごしています。",
+      profileLink: "",
+    },
+  });
+
   await prisma.follow.createMany({
     data: [
       { followerId: alice.id, followingId: kota.id },
       { followerId: kota.id, followingId: mina.id },
       { followerId: mina.id, followingId: alice.id },
+      { followerId: ren.id, followingId: alice.id },
+      { followerId: ren.id, followingId: kota.id },
+      { followerId: ren.id, followingId: mina.id },
+      { followerId: alice.id, followingId: ren.id },
+      { followerId: kota.id, followingId: ren.id },
+      { followerId: mina.id, followingId: ren.id },
     ],
   });
 
@@ -309,11 +332,197 @@ async function main() {
     },
   });
 
+  const postAlice3 = await prisma.post.create({
+    data: {
+      title: "キッチンは白ベース",
+      description: "調理はコンパクトに。見せる収納は同系色だけにしています。",
+      category: "kitchen",
+      housingType: "rental",
+      layoutType: "1ldk",
+      roomContextNote: "",
+      userId: alice.id,
+      medias: {
+        create: [
+          { path: IMG.kitchen, mood: "warm" },
+          { path: IMG.dining, mood: "ambient_light" },
+        ],
+      },
+      styleTags: {
+        create: [
+          { tagSlug: "tidying" },
+          { tagSlug: "compact" },
+          { tagSlug: "rental" },
+          { tagSlug: "budget_mix" },
+        ],
+      },
+      furnitureItems: {
+        create: [
+          {
+            name: "キッチンマット",
+            brand: "ニトリ",
+            brandSlug: "",
+            productUrl: "https://www.nitori-net.jp/ec/",
+            productHost: "nitori-net.jp",
+            note: "1枚目の足元",
+            sortOrder: 0,
+            mediaIndex: 0,
+            pinX: 0.4,
+            pinY: 0.78,
+            price: 1990,
+            linkRelation: "purchased",
+            linkVerifiedAt: new Date("2024-08-20T00:00:00.000Z"),
+          },
+          {
+            name: "ダイニングチェア",
+            brand: "",
+            brandSlug: "",
+            productUrl: "https://www.muji.com/jp/ja/store",
+            productHost: "muji.com",
+            note: "2枚目",
+            sortOrder: 1,
+            mediaIndex: 1,
+            pinX: 0.55,
+            pinY: 0.42,
+            price: 12900,
+            linkRelation: "same_model",
+            linkVerifiedAt: null,
+          },
+        ],
+      },
+    },
+  });
+
+  const postMina2 = await prisma.post.create({
+    data: {
+      title: "読書用の壁一面",
+      description: "電子より紙派。新刊は積まずに読み終えたら出す。",
+      category: "study",
+      housingType: "rental",
+      layoutType: "1k_1dk",
+      roomContextNote: "",
+      userId: mina.id,
+      medias: { create: [{ path: IMG.bookshelf, mood: "ambient_light" }] },
+      styleTags: {
+        create: [
+          { tagSlug: "reading" },
+          { tagSlug: "minimalist" },
+          { tagSlug: "ambient_light" },
+          { tagSlug: "solo_living" },
+        ],
+      },
+      furnitureItems: {
+        create: [
+          {
+            name: "読書灯",
+            brand: "",
+            brandSlug: "",
+            productUrl: "https://www.amazon.co.jp/",
+            productHost: "amazon.co.jp",
+            note: "",
+            sortOrder: 0,
+            mediaIndex: 0,
+            pinX: 0.33,
+            pinY: 0.4,
+            price: 4980,
+            linkRelation: "purchased",
+            linkVerifiedAt: new Date("2025-02-01T00:00:00.000Z"),
+          },
+        ],
+      },
+    },
+  });
+
+  const postRen1 = await prisma.post.create({
+    data: {
+      title: "週末のダイニング",
+      description: "友人が来るときはこのテーブルを中心に。平日は片付けて広く。",
+      category: "dining",
+      housingType: "rental",
+      layoutType: "2ldk",
+      roomContextNote: "",
+      userId: ren.id,
+      medias: { create: [{ path: IMG.dining, mood: "warm" }] },
+      styleTags: {
+        create: [
+          { tagSlug: "warm" },
+          { tagSlug: "solo_living" },
+          { tagSlug: "nakameguro" },
+          { tagSlug: "budget_retail" },
+        ],
+      },
+      furnitureItems: {
+        create: [
+          {
+            name: "ダイニングテーブル",
+            brand: "",
+            brandSlug: "",
+            productUrl: "https://www.ikea.com/jp/ja/",
+            productHost: "ikea.com",
+            note: "",
+            sortOrder: 0,
+            mediaIndex: 0,
+            pinX: 0.5,
+            pinY: 0.48,
+            price: 34990,
+            linkRelation: "purchased",
+            linkVerifiedAt: new Date("2024-05-01T00:00:00.000Z"),
+          },
+        ],
+      },
+    },
+  });
+
+  const postRen2 = await prisma.post.create({
+    data: {
+      title: "玄関からリビングへの動線",
+      description: "靴箱はスリム型。鏡で奥行きを補っています。",
+      category: "entrance",
+      housingType: "rental",
+      layoutType: "2ldk",
+      roomContextNote: "",
+      userId: ren.id,
+      medias: { create: [{ path: IMG.hallway, mood: "concrete" }] },
+      styleTags: {
+        create: [
+          { tagSlug: "compact" },
+          { tagSlug: "mukishitsu" },
+          { tagSlug: "rental" },
+          { tagSlug: "tidying" },
+        ],
+      },
+      furnitureItems: {
+        create: [
+          {
+            name: "壁掛けミラー",
+            brand: "",
+            brandSlug: "",
+            productUrl: "https://www.nitori-net.jp/ec/",
+            productHost: "nitori-net.jp",
+            note: "",
+            sortOrder: 0,
+            mediaIndex: 0,
+            pinX: 0.62,
+            pinY: 0.35,
+            price: 5990,
+            linkRelation: "reference",
+            linkVerifiedAt: null,
+          },
+        ],
+      },
+    },
+  });
+
   await prisma.like.createMany({
     data: [
       { userId: alice.id, postId: postKota1.id },
       { userId: kota.id, postId: postAlice1.id },
       { userId: mina.id, postId: postAlice2.id },
+      { userId: ren.id, postId: postAlice1.id },
+      { userId: ren.id, postId: postMina2.id },
+      { userId: alice.id, postId: postRen1.id },
+      { userId: kota.id, postId: postRen2.id },
+      { userId: mina.id, postId: postAlice3.id },
+      { userId: kota.id, postId: postMina2.id },
     ],
   });
 
@@ -321,6 +530,9 @@ async function main() {
     data: [
       { userId: mina.id, postId: postAlice1.id },
       { userId: alice.id, postId: postMina1.id },
+      { userId: kota.id, postId: postAlice3.id },
+      { userId: mina.id, postId: postRen1.id },
+      { userId: ren.id, postId: postKota2.id },
     ],
   });
 
@@ -342,9 +554,37 @@ async function main() {
     });
   }
 
+  const minaReadingLamp = await prisma.furnitureItem.findFirst({
+    where: { postId: postMina2.id, name: "読書灯" },
+    select: { productUrl: true },
+  });
+  if (minaReadingLamp) {
+    await prisma.itemWishlist.create({
+      data: {
+        userId: kota.id,
+        name: "読書灯",
+        productUrl: minaReadingLamp.productUrl,
+        note: "寝室のサイドに",
+        sourcePostId: postMina2.id,
+        price: 4980,
+        buyRank: 2,
+      },
+    });
+  }
+
   console.log("Seed OK:", {
-    users: [alice.email, kota.email, mina.email],
-    posts: [postAlice1.id, postAlice2.id, postKota1.id, postKota2.id, postMina1.id],
+    users: [alice.email, kota.email, mina.email, ren.email],
+    posts: [
+      postAlice1.id,
+      postAlice2.id,
+      postAlice3.id,
+      postKota1.id,
+      postKota2.id,
+      postMina1.id,
+      postMina2.id,
+      postRen1.id,
+      postRen2.id,
+    ],
   });
 }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -109,7 +109,7 @@ export default async function DashboardPage() {
   return (
     <div className="nook-app-canvas min-h-screen">
       <div className="nook-page nook-safe-page-pb pt-8 sm:pt-10">
-        <header className="dashboard-page-header nook-elevated-surface mb-8 overflow-hidden p-5 sm:mb-10 sm:p-6">
+        <header className="nook-elevated-surface mb-8 overflow-hidden p-5 sm:mb-10 sm:p-6">
           <div className="flex items-start gap-4">
             <div className="nook-avatar-letter h-16 w-16 shrink-0">
               {(user.name && user.name.trim()[0]) || "?"}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -122,6 +122,15 @@ body {
   touch-action: manipulation;
 }
 
+/** モバイルのタップ時フラッシュをニュートラルに（§6 コンクリ寄り） */
+button,
+[role="button"],
+a[href],
+label[for],
+summary {
+  -webkit-tap-highlight-color: color-mix(in srgb, var(--text) 7%, transparent);
+}
+
 /** layout.tsx の body に付与（インラインの集約） */
 .nook-body-surface {
   background: var(--bg);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -42,9 +42,24 @@ function LoginForm() {
 
       {/* 右：フォーム面 */}
       <div className="w-full max-w-md flex-1">
+        {/* スマホのみ：入口層の温度感（§5.1）。左カラムと同じ写真で軽くムードを足す */}
+        <div className="relative mb-5 aspect-[16/10] w-full overflow-hidden rounded-[var(--radius-card)] shadow-[var(--home-tile-shadow)] sm:hidden">
+          <Image
+            src={HOME_HERO_IMAGE_SRC}
+            alt=""
+            fill
+            className="object-cover object-[center_40%]"
+            sizes="(max-width: 639px) 100vw, 0px"
+            priority
+            quality={90}
+          />
+          <div className="login-visual-scrim absolute inset-0" />
+          <p className="login-hero-caption absolute bottom-3 left-4 right-4 text-[11px] font-medium leading-relaxed">
+            自分の部屋を、もう少し好きになる。
+          </p>
+        </div>
         <div className="nook-elevated-surface space-y-6 overflow-hidden p-5 sm:p-7">
-          {/* 入口層：ムードと部屋を先に。チラシ感は出さない */}
-          <header className="login-entry-header">
+          <header>
             <div className="mb-5 flex items-center gap-3">
               <span className="nook-fg" aria-hidden>
                 <Logo size={40} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -253,7 +253,7 @@ export default async function HomePage({
               {followingFeed
                 ? "フォロー中の部屋は、まだありません"
                 : isFiltered
-                  ? "該当する部屋は、まだ見つからないようです"
+                  ? "該当する部屋は、まだありません"
                   : "まだ部屋がありません"}
             </p>
             <p className="nook-fg-muted mt-2 text-[13px] leading-relaxed">

--- a/src/app/post/[id]/edit/page.tsx
+++ b/src/app/post/[id]/edit/page.tsx
@@ -62,6 +62,7 @@ export default async function EditPostPage({ params }: { params: Promise<{ id: s
         <div className="nook-elevated-surface overflow-hidden p-5 sm:p-6">
           <Link
             href={`/post/${id}`}
+            scroll={false}
             className="nook-fg-muted inline-flex min-h-[var(--touch)] items-center gap-2 text-xs font-medium transition hover:opacity-75"
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden>

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -270,7 +270,7 @@ export default async function PostPage({ params }: { params: Promise<{ id: strin
           </div>
 
           <div className="nook-post-toolbar-surface mt-6 flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-card)] border p-4 sm:p-5">
-            <p className="sr-only">この部屋の写真を載せた人</p>
+            <p className="sr-only">この部屋を載せた人</p>
             <Link href={`/user/${post.user.id}`} className="flex min-w-0 items-center gap-3 transition hover:opacity-85">
               <div className="nook-avatar-letter h-11 w-11 shrink-0 !text-sm">
                 {(post.user.name && post.user.name.trim()[0]) || "?"}

--- a/src/app/shop/[host]/page.tsx
+++ b/src/app/shop/[host]/page.tsx
@@ -60,15 +60,15 @@ export default async function ShopByHostPage({ params }: { params: Promise<{ hos
   return (
     <div className="nook-app-canvas min-h-screen">
       <div className="nook-page nook-safe-page-pb pt-6 sm:pt-8">
-        <header className="shop-page-header nook-elevated-surface mb-8 overflow-hidden p-5 sm:mb-9 sm:p-6">
+        <header className="nook-elevated-surface mb-8 overflow-hidden p-5 sm:mb-9 sm:p-6">
           <p className="nook-section-label mb-2">ショップ別</p>
           <h1 className="nook-fg text-lg font-semibold tracking-tight sm:text-xl">
-            <span className="nook-shop-host-chip shop-page-host block break-words rounded-[var(--radius-card)] border px-3 py-2.5 text-[0.8125rem] font-medium leading-snug tracking-normal sm:px-3.5 sm:py-3 sm:text-sm">
+            <span className="nook-shop-host-chip block break-words rounded-[var(--radius-card)] border px-3 py-2.5 text-[0.8125rem] font-medium leading-snug tracking-normal sm:px-3.5 sm:py-3 sm:text-sm">
               {decoded}
             </span>
           </h1>
           <div
-            className="shop-page-stats nook-fg-muted mt-4 flex w-full flex-wrap items-baseline gap-x-2 gap-y-1 border-t border-b py-3 text-[11px] tabular-nums nook-border-hairline"
+            className="nook-fg-muted mt-4 flex w-full flex-wrap items-baseline gap-x-2 gap-y-1 border-t border-b py-3 text-[11px] tabular-nums nook-border-hairline"
             aria-label="件数"
           >
             <span className="nook-fg text-sm font-semibold">
@@ -78,7 +78,7 @@ export default async function ShopByHostPage({ params }: { params: Promise<{ hos
           </div>
         </header>
 
-        <section className="shop-page-grid-section" aria-labelledby="shop-posts-heading">
+        <section aria-labelledby="shop-posts-heading">
           <h2 id="shop-posts-heading" className="nook-section-label mb-1">
             部屋
           </h2>
@@ -102,7 +102,7 @@ export default async function ShopByHostPage({ params }: { params: Promise<{ hos
                 まだ部屋がありません
               </p>
               <p className="nook-fg-muted mt-1 max-w-xs px-4 text-xs leading-relaxed">
-                このショップの商品ページが載った部屋はまだないようです。みんなの部屋から探してみてください。
+                このショップの商品ページが載っている部屋は、まだありません。みんなの部屋からさがせます。
               </p>
               <Link href="/" className="btn-secondary mt-6 text-sm sm:text-xs">
                 みんなの部屋を見る

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
-import { prisma } from "@/lib/prisma";
-import { getOptionalUserId } from "@/lib/session-user";
 import FollowButton from "@/components/follow-button";
 import HomePostGrid from "@/components/home-post-grid";
+import PageBackLink from "@/components/page-back-link";
+import { prisma } from "@/lib/prisma";
+import { getOptionalUserId } from "@/lib/session-user";
 import { getCategoryLabel } from "@/lib/categories";
 import { getStyleTagLabel } from "@/lib/style-tags";
 import { formatYearMonthJa } from "@/lib/format-date-ja";
@@ -107,7 +108,7 @@ export default async function UserProfilePage({ params }: { params: Promise<{ id
   return (
     <div className="nook-app-canvas min-h-screen">
       <div className="nook-page nook-safe-page-pb pt-6 sm:pt-8">
-        <header className="user-profile-header nook-elevated-surface mb-8 overflow-hidden p-5 sm:mb-9 sm:p-6">
+        <header className="nook-elevated-surface mb-8 overflow-hidden p-5 sm:mb-9 sm:p-6">
           <p className="nook-section-label mb-2">プロフィール</p>
 
           <div className="mt-1 flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
@@ -133,6 +134,7 @@ export default async function UserProfilePage({ params }: { params: Promise<{ id
                     target="_blank"
                     rel="noopener noreferrer"
                     className="nook-fg-muted mt-3 inline-flex min-h-11 items-center gap-1 rounded-md px-1 py-2 text-xs font-semibold underline decoration-transparent underline-offset-2 transition hover:opacity-85 sm:min-h-0 sm:px-0 sm:py-0"
+                    aria-label="プロフィールのリンクを別のタブで開く"
                   >
                     リンクを開く
                     <svg width="10" height="10" viewBox="0 0 14 14" fill="none" aria-hidden>
@@ -260,6 +262,10 @@ export default async function UserProfilePage({ params }: { params: Promise<{ id
             </div>
           )}
         </section>
+
+        <div className="mt-10 border-t pt-6 nook-border-hairline">
+          <PageBackLink />
+        </div>
       </div>
     </div>
   );

--- a/src/components/bookmark-button.tsx
+++ b/src/components/bookmark-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import { useSession } from "next-auth/react";
 import { usePathname, useRouter } from "next/navigation";
 import { loginCallbackHref } from "@/lib/login-href";
@@ -12,7 +12,7 @@ export default function BookmarkButton({ postId, initialBookmarked, size = "md" 
   const router = useRouter();
   const pathname = usePathname();
   const [bookmarked, setBookmarked] = useState(initialBookmarked);
-  const [isPending, startTransition] = useTransition();
+  const [pending, setPending] = useState(false);
 
   async function toggleBookmark(e: React.MouseEvent) {
     e.preventDefault();
@@ -21,22 +21,29 @@ export default function BookmarkButton({ postId, initialBookmarked, size = "md" 
       router.push(loginCallbackHref(pathname));
       return;
     }
-    setBookmarked((prev) => !prev);
-    startTransition(async () => {
-      try {
-        const res = await fetch("/api/bookmarks", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ postId }),
-        });
-        if (res.ok) {
-          const data = (await res.json()) as { bookmarked?: boolean };
-          if (typeof data.bookmarked === "boolean") setBookmarked(data.bookmarked);
-        }
-      } catch {
-        setBookmarked((prev) => !prev);
+    if (pending) return;
+    setPending(true);
+
+    const was = bookmarked;
+    setBookmarked(!was);
+
+    try {
+      const res = await fetch("/api/bookmarks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ postId }),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { bookmarked?: boolean };
+        if (typeof data.bookmarked === "boolean") setBookmarked(data.bookmarked);
+      } else {
+        setBookmarked(was);
       }
-    });
+    } catch {
+      setBookmarked(was);
+    } finally {
+      setPending(false);
+    }
   }
 
   const iconSize = size === "sm" ? 16 : 20;
@@ -44,9 +51,8 @@ export default function BookmarkButton({ postId, initialBookmarked, size = "md" 
     <button
       type="button"
       onClick={toggleBookmark}
-      disabled={isPending}
-      aria-busy={isPending}
-      className={`group inline-flex items-center justify-center transition active:scale-[0.96] ${bookmarked ? "nook-fg" : "nook-fg-muted"} ${size === "sm" ? "min-h-11 min-w-11 rounded-md p-1 sm:min-h-9 sm:min-w-9" : "min-h-11 min-w-11 px-2 py-2 sm:min-h-0 sm:min-w-0 sm:px-2 sm:py-1.5"}`}
+      aria-busy={pending}
+      className={`group inline-flex items-center justify-center transition active:scale-[0.96] ${pending ? "pointer-events-none opacity-80" : ""} ${bookmarked ? "nook-fg" : "nook-fg-muted"} ${size === "sm" ? "min-h-11 min-w-11 rounded-md p-1 sm:min-h-9 sm:min-w-9" : "min-h-11 min-w-11 px-2 py-2 sm:min-h-0 sm:min-w-0 sm:px-2 sm:py-1.5"}`}
       aria-label={bookmarked ? "保存を取り消す" : "保存する"} aria-pressed={bookmarked}
     >
       <svg width={iconSize} height={iconSize} viewBox="0 0 24 24" aria-hidden>

--- a/src/components/broken-image-placeholder.tsx
+++ b/src/components/broken-image-placeholder.tsx
@@ -1,0 +1,45 @@
+import type { CSSProperties } from "react";
+import { getMoodFilter } from "@/lib/image-mood";
+
+type Props = {
+  /** スクリーンリーダー向け（空なら既定文言） */
+  label?: string;
+  mood?: string;
+  compact?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  /** 親が `relative` のとき、画像と同様に領域を埋める */
+  absoluteFill?: boolean;
+};
+
+/**
+ * 外部 URL・画像最適化の失敗時などに表示するプレースホルダー（next/image の代替）
+ */
+export function BrokenImagePlaceholder({
+  label = "画像を読み込めませんでした",
+  mood,
+  compact = false,
+  className = "",
+  style,
+  absoluteFill = false,
+}: Props) {
+  const size = compact ? 20 : 32;
+  const filterStyle: CSSProperties | undefined = mood
+    ? { filter: getMoodFilter(mood) }
+    : undefined;
+
+  return (
+    <div
+      className={`flex items-center justify-center nook-bg-wash nook-fg-faint ${absoluteFill ? "absolute inset-0" : ""} ${className}`.trim()}
+      style={{ ...filterStyle, ...style }}
+      role="img"
+      aria-label={label}
+    >
+      <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden>
+        <rect x="3" y="3" width="18" height="18" rx="2" stroke="currentColor" strokeWidth="1.5" />
+        <circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" />
+        <path d="M21 15l-5-5L5 21" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    </div>
+  );
+}

--- a/src/components/category-filter.tsx
+++ b/src/components/category-filter.tsx
@@ -1,57 +1,39 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { useTransition } from "react";
 import { CATEGORIES } from "@/lib/categories";
-import { buildHomeHref } from "@/lib/home-href";
 import CategoryIcon from "@/components/category-icon";
+import { useHomeFilterDraft } from "@/components/home-filter-draft";
 
 export default function CategoryFilter() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const current = searchParams.get("category") ?? "";
-  const [isPending, startTransition] = useTransition();
-
-  function select(value: string) {
-    startTransition(() => {
-      router.push(
-        buildHomeHref(searchParams, (p) => {
-          if (value) p.set("category", value);
-          else p.delete("category");
-        })
-      );
-    });
-  }
+  const { draft, setCategory, isPending } = useHomeFilterDraft();
+  const current = draft.category;
 
   return (
-    <div
-      className={`flex flex-col gap-1 ${isPending ? "pointer-events-none opacity-60" : ""}`}
-      aria-busy={isPending}
-    >
+    <div className="flex flex-col gap-1" aria-busy={isPending}>
       <p className="nook-overline nook-overline--sentence mb-0">カテゴリ</p>
       <div className="flex gap-0 overflow-x-auto scrollbar-hide" role="tablist" aria-label="カテゴリ">
-      <button
-        type="button"
-        role="tab"
-        aria-selected={!current}
-        onClick={() => select("")}
-        className="filter-chip"
-      >
-        すべて
-      </button>
-      {CATEGORIES.filter((c) => c.value !== "other").map((cat) => (
         <button
-          key={cat.value}
           type="button"
           role="tab"
-          aria-selected={current === cat.value}
-          onClick={() => select(cat.value)}
-          className="filter-chip flex items-center gap-1"
+          aria-selected={!current}
+          onClick={() => setCategory("")}
+          className="filter-chip"
         >
-          <CategoryIcon value={cat.value} size={12} />
-          {cat.label}
+          すべて
         </button>
-      ))}
+        {CATEGORIES.filter((c) => c.value !== "other").map((cat) => (
+          <button
+            key={cat.value}
+            type="button"
+            role="tab"
+            aria-selected={current === cat.value}
+            onClick={() => setCategory(cat.value)}
+            className="filter-chip flex items-center gap-1"
+          >
+            <CategoryIcon value={cat.value} size={12} />
+            {cat.label}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/components/create-post.tsx
+++ b/src/components/create-post.tsx
@@ -582,7 +582,7 @@ export default function CreatePost() {
       <div className="create-post-flow animate-fade-in">
         {stepBar}
         <p className="nook-section-label mb-1">確認</p>
-        <h2 id="modal-title" className="nook-fg mb-1 text-base font-semibold tracking-tight">
+        <h2 className="nook-fg mb-1 text-base font-semibold tracking-tight">
           送信前の確認
         </h2>
         <PostModalDesc>問題なければ載せてください。</PostModalDesc>
@@ -596,6 +596,7 @@ export default function CreatePost() {
               showFullscreenButton={false}
               showNav={confirmGalleryItems.length > 1}
               showBullets={false}
+              onErrorImageURL="/empty-state.png"
               renderLeftNav={renderNookGalleryLeftNav}
               renderRightNav={renderNookGalleryRightNav}
             />
@@ -711,7 +712,7 @@ export default function CreatePost() {
       <div className="create-post-flow animate-fade-in">
         {stepBar}
         <p className="nook-section-label mb-1">家具・雑貨</p>
-        <h2 id="modal-title" className="nook-fg mb-1 text-base font-semibold tracking-tight">
+        <h2 className="nook-fg mb-1 text-base font-semibold tracking-tight">
           家具・雑貨のリンク（任意）
         </h2>
         <PostModalDesc>
@@ -980,7 +981,7 @@ export default function CreatePost() {
       ) : null}
       {stepBar}
       <p className="nook-section-label mb-1">載せる</p>
-      <h2 id="modal-title" className="nook-fg mb-1 text-base font-semibold tracking-tight">
+      <h2 className="nook-fg mb-1 text-base font-semibold tracking-tight">
         写真を載せる
       </h2>
       <PostModalDesc>

--- a/src/components/dashboard-content.tsx
+++ b/src/components/dashboard-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useTransition } from "react";
 import DashboardPosts from "./dashboard-posts";
 import DashboardWishlist, { type WishlistRow } from "./dashboard-wishlist";
 import Link from "next/link";
@@ -41,9 +41,12 @@ export default function DashboardContent({
     spTab === "bookmarks" || spTab === "wishlist" || spTab === "posts" ? spTab : "posts";
   const [postCategory, setPostCategory] = useState<string>("");
   const [postQuery, setPostQuery] = useState("");
+  const [, startNavTransition] = useTransition();
 
   function goTab(next: "posts" | "bookmarks" | "wishlist") {
-    router.replace(next === "posts" ? "/dashboard" : `/dashboard?tab=${next}`, { scroll: false });
+    startNavTransition(() => {
+      router.replace(next === "posts" ? "/dashboard" : `/dashboard?tab=${next}`, { scroll: false });
+    });
   }
 
   const filteredPosts = useMemo(() => {
@@ -56,7 +59,7 @@ export default function DashboardContent({
   }, [posts, postCategory, postQuery]);
 
   return (
-    <section className="dashboard-main-section" aria-labelledby="dashboard-main-heading">
+    <section aria-labelledby="dashboard-main-heading">
       <h2 id="dashboard-main-heading" className="nook-section-label mb-3 mt-0">
         部屋・保存・欲しい
       </h2>
@@ -190,7 +193,7 @@ export default function DashboardContent({
           ) : (
             <EmptyState
               icon="wish"
-              title="欲しいに、まだありません。"
+              title="欲しいは、まだありません"
               description="気になった家具・雑貨を入れておくと、あとからまとめて見返せます。"
             />
           )

--- a/src/components/dashboard-posts.tsx
+++ b/src/components/dashboard-posts.tsx
@@ -90,6 +90,8 @@ export default function DashboardPosts({ posts }: { posts: Post[] }) {
                     type="button"
                     onClick={() => handleDelete(post.id)}
                     disabled={!!deleting}
+                    aria-busy={deleting === post.id}
+                    aria-label={deleting === post.id ? "削除しています" : undefined}
                     className={`nook-dash-post-btn-danger ${DASH_POST_ACTION_CLASS} disabled:opacity-50`}
                   >
                     {deleting === post.id ? "…" : "削除する"}
@@ -110,6 +112,7 @@ export default function DashboardPosts({ posts }: { posts: Post[] }) {
                       e.preventDefault();
                       setConfirmId(post.id);
                     }}
+                    aria-label={post.title ? `「${post.title}」を削除` : "この部屋を削除"}
                     className={`nook-dash-post-btn-ghost ${DASH_POST_ACTION_CLASS}`}
                   >
                     削除

--- a/src/components/dashboard-wishlist.tsx
+++ b/src/components/dashboard-wishlist.tsx
@@ -140,6 +140,11 @@ export default function DashboardWishlist({ items }: { items: WishlistRow[] }) {
               target="_blank"
               rel="noopener noreferrer"
               className="btn-primary text-sm sm:text-xs"
+              aria-label={
+                urlMeta
+                  ? `${w.name} の商品ページ（${urlMeta.displayHost}）を別のタブで開く`
+                  : `${w.name} の商品ページを別のタブで開く`
+              }
             >
               商品ページを開く
             </a>
@@ -149,7 +154,7 @@ export default function DashboardWishlist({ items }: { items: WishlistRow[] }) {
               disabled={removing === w.id}
               aria-busy={removing === w.id}
               className="btn-secondary text-sm sm:text-xs disabled:opacity-50"
-              aria-label={`${w.name} を欲しいから外す`}
+              aria-label={removing === w.id ? "外しています" : `${w.name} を欲しいから外す`}
             >
               {removing === w.id ? "…" : "外す"}
             </button>

--- a/src/components/edit-post-form.tsx
+++ b/src/components/edit-post-form.tsx
@@ -549,7 +549,13 @@ export default function EditPostForm({ initial }: { initial: EditPostInitial }) 
       ) : null}
 
       <div className="flex flex-wrap gap-3">
-        <button type="submit" disabled={loading} className="btn-primary text-sm sm:text-xs disabled:opacity-50">
+        <button
+          type="submit"
+          disabled={loading}
+          aria-busy={loading}
+          aria-label={loading ? "更新しています" : undefined}
+          className="btn-primary text-sm sm:text-xs disabled:opacity-50"
+        >
           {loading ? "更新中…" : "更新する"}
         </button>
         <Link href={`/post/${initial.id}`} className="btn-secondary text-sm sm:text-xs">

--- a/src/components/follow-button.tsx
+++ b/src/components/follow-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import { useSession } from "next-auth/react";
 import { usePathname, useRouter } from "next/navigation";
 import { loginCallbackHref } from "@/lib/login-href";
@@ -23,7 +23,7 @@ export default function FollowButton({
   const pathname = usePathname();
   const [following, setFollowing] = useState(initialFollowing);
   const [followerCount, setFollowerCount] = useState(initialFollowerCount);
-  const [isPending, startTransition] = useTransition();
+  const [pending, setPending] = useState(false);
 
   async function toggle(e: React.MouseEvent) {
     e.preventDefault();
@@ -32,27 +32,35 @@ export default function FollowButton({
       router.push(loginCallbackHref(pathname));
       return;
     }
-    const next = !following;
+    if (pending) return;
+    setPending(true);
+
+    const wasFollowing = following;
+    const prevCount = followerCount;
+    const next = !wasFollowing;
     setFollowing(next);
     setFollowerCount((c) => (next ? c + 1 : Math.max(0, c - 1)));
-    startTransition(async () => {
-      try {
-        const res = await fetch("/api/follows", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ userId }),
-        });
-        if (res.ok) {
-          const data = (await res.json()) as { following: boolean; followerCount: number };
-          setFollowing(data.following);
-          setFollowerCount(data.followerCount);
-          router.refresh();
-        }
-      } catch {
-        setFollowing((prev) => !prev);
-        setFollowerCount((c) => (next ? Math.max(0, c - 1) : c + 1));
+
+    try {
+      const res = await fetch("/api/follows", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId }),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { following: boolean; followerCount: number };
+        setFollowing(data.following);
+        setFollowerCount(data.followerCount);
+      } else {
+        setFollowing(wasFollowing);
+        setFollowerCount(prevCount);
       }
-    });
+    } catch {
+      setFollowing(wasFollowing);
+      setFollowerCount(prevCount);
+    } finally {
+      setPending(false);
+    }
   }
 
   const pad =
@@ -60,13 +68,17 @@ export default function FollowButton({
       ? "min-h-11 px-3 py-2 text-xs sm:min-h-0 sm:py-1 sm:text-[11px]"
       : "min-h-11 px-4 py-2 text-xs sm:min-h-0 sm:py-1.5";
 
+  const label = following
+    ? `フォロー中、フォロワー${followerCount}人`
+    : `フォローする（フォロワー${followerCount}人）`;
+
   return (
     <button
       type="button"
       onClick={toggle}
-      disabled={isPending}
-      aria-busy={isPending}
-      className={`inline-flex items-center justify-center rounded-full font-bold transition active:scale-[0.97] disabled:opacity-60 ${pad} ${className}`}
+      aria-busy={pending}
+      aria-label={label}
+      className={`inline-flex items-center justify-center rounded-full font-bold transition active:scale-[0.97] ${pending ? "pointer-events-none opacity-80" : ""} ${pad} ${className}`}
       style={
         following
           ? {
@@ -82,7 +94,7 @@ export default function FollowButton({
       }
       aria-pressed={following}
     >
-      {following ? "フォロー中" : "フォロー"}
+      <span aria-hidden>{following ? "フォロー中" : "フォロー"}</span>
       <span className="ml-1.5 tabular-nums opacity-80" aria-hidden>
         {followerCount}
       </span>

--- a/src/components/furniture-photo-pin-picker.tsx
+++ b/src/components/furniture-photo-pin-picker.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import { clampPinUnit } from "@/lib/furniture-pin-coords";
+import { BrokenImagePlaceholder } from "@/components/broken-image-placeholder";
 
 type Props = {
   imageSrc: string;
@@ -11,13 +13,21 @@ type Props = {
   caption?: string;
 };
 
-export default function FurniturePhotoPinPicker({
+/** `imageSrc` が変わるたびに外から `key` を付けてマウントし、読み込み失敗状態をリセットする */
+function PinPickerSurface({
   imageSrc,
   pinX,
   pinY,
   onChange,
-  caption = "写真をタップで位置を付けます（任意）",
-}: Props) {
+}: {
+  imageSrc: string;
+  pinX: number | null;
+  pinY: number | null;
+  onChange: (next: { pinX: number | null; pinY: number | null }) => void;
+}) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const onImgError = useCallback(() => setImgFailed(true), []);
+
   function handleImgClick(e: React.MouseEvent<HTMLImageElement>) {
     const el = e.currentTarget;
     const w = el.offsetWidth;
@@ -31,16 +41,20 @@ export default function FurniturePhotoPinPicker({
   const hasPin = pinX !== null && pinY !== null;
 
   return (
-    <div className="mt-2 space-y-1.5">
-      <p className="nook-fg-muted text-[10px] font-semibold leading-snug">{caption}</p>
+    <>
       <div className="relative aspect-[4/5] w-full max-w-[11rem] overflow-hidden rounded-[var(--radius-sm)] border nook-border-hairline bg-black/5 dark:bg-white/5">
-        <img
-          src={imageSrc}
-          alt=""
-          className="absolute inset-0 h-full w-full cursor-crosshair object-cover"
-          onClick={handleImgClick}
-          draggable={false}
-        />
+        {imgFailed ? (
+          <BrokenImagePlaceholder absoluteFill compact label="写真を表示できません" />
+        ) : (
+          <img
+            src={imageSrc}
+            alt=""
+            className="absolute inset-0 h-full w-full cursor-crosshair object-cover"
+            onClick={handleImgClick}
+            onError={onImgError}
+            draggable={false}
+          />
+        )}
         {hasPin ? (
           <span
             className="pointer-events-none absolute z-[1] h-3 w-3 rounded-full border-2 border-white bg-[var(--accent)] shadow-md"
@@ -57,10 +71,25 @@ export default function FurniturePhotoPinPicker({
         type="button"
         onClick={() => onChange({ pinX: null, pinY: null })}
         disabled={!hasPin}
-        className="text-[10px] font-medium text-[var(--text-muted)] underline decoration-[var(--border)] underline-offset-2 transition hover:opacity-90 disabled:pointer-events-none disabled:opacity-40"
+        className="min-h-8 text-[10px] font-medium text-[var(--text-muted)] underline decoration-[var(--border)] underline-offset-2 transition hover:opacity-90 disabled:pointer-events-none disabled:opacity-40 sm:min-h-0"
       >
         位置を消す
       </button>
+    </>
+  );
+}
+
+export default function FurniturePhotoPinPicker({
+  imageSrc,
+  pinX,
+  pinY,
+  onChange,
+  caption = "写真をタップで位置を付けます（任意）",
+}: Props) {
+  return (
+    <div className="mt-2 space-y-1.5">
+      <p className="nook-fg-muted text-[10px] font-semibold leading-snug">{caption}</p>
+      <PinPickerSurface key={imageSrc} imageSrc={imageSrc} pinX={pinX} pinY={pinY} onChange={onChange} />
     </div>
   );
 }

--- a/src/components/home-filter-draft.tsx
+++ b/src/components/home-filter-draft.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type ReactNode,
+} from "react";
+import { useRouter, useSearchParams, type ReadonlyURLSearchParams } from "next/navigation";
+import { parseStyleSlugsFromSearchParams } from "@/lib/feed-styles";
+
+const DEBOUNCE_MS = 300;
+
+export type HomeFilterDraft = {
+  category: string;
+  styleSlugs: string[];
+  minPrice: string | null;
+  maxPrice: string | null;
+};
+
+function readDraft(sp: ReadonlyURLSearchParams): HomeFilterDraft {
+  return {
+    category: sp.get("category")?.trim() ?? "",
+    styleSlugs: parseStyleSlugsFromSearchParams({
+      styles: sp.get("styles") ?? undefined,
+      style: sp.get("style") ?? undefined,
+    }),
+    minPrice: sp.get("minPrice"),
+    maxPrice: sp.get("maxPrice"),
+  };
+}
+
+function applyDraft(params: URLSearchParams, d: HomeFilterDraft) {
+  if (d.category) params.set("category", d.category);
+  else params.delete("category");
+
+  params.delete("style");
+  const sorted = [...new Set(d.styleSlugs)].filter(Boolean).sort();
+  if (sorted.length > 0) params.set("styles", sorted.join(","));
+  else params.delete("styles");
+
+  if (d.minPrice) params.set("minPrice", d.minPrice);
+  else params.delete("minPrice");
+  if (d.maxPrice) params.set("maxPrice", d.maxPrice);
+  else params.delete("maxPrice");
+}
+
+type Ctx = {
+  draft: HomeFilterDraft;
+  setCategory: (value: string) => void;
+  toggleStyle: (slug: string) => void;
+  clearStyles: () => void;
+  setPriceBracket: (min: number | null, max: number | null) => void;
+  /** パネルを閉じる直前など、保留中の変更をすぐ URL に反映する */
+  flushNow: () => void;
+  isPending: boolean;
+};
+
+const HomeFilterDraftContext = createContext<Ctx | null>(null);
+
+export function useHomeFilterDraft() {
+  const ctx = useContext(HomeFilterDraftContext);
+  if (!ctx) throw new Error("useHomeFilterDraft must be used within HomeFilterDraftProvider");
+  return ctx;
+}
+
+/**
+ * カテゴリ・スタイル・価格の変更をローカルに溜め、短いデバウンスで 1 回の router.replace にまとめる。
+ * 親で `key={searchParams.toString()}` を付け、URL が外から変わったときは状態をリセットする。
+ */
+export function HomeFilterDraftProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [draft, setDraft] = useState<HomeFilterDraft>(() => readDraft(searchParams));
+  const [isPending, startTransition] = useTransition();
+
+  const draftRef = useRef(draft);
+  const spRef = useRef(searchParams);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    draftRef.current = draft;
+    spRef.current = searchParams;
+  }, [draft, searchParams]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const pushDraft = useCallback(() => {
+    const p = new URLSearchParams(spRef.current.toString());
+    applyDraft(p, draftRef.current);
+    const qs = p.toString();
+    startTransition(() => {
+      router.replace(qs ? `/?${qs}` : "/", { scroll: false });
+    });
+  }, [router, startTransition]);
+
+  const schedulePush = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      pushDraft();
+    }, DEBOUNCE_MS);
+  }, [pushDraft]);
+
+  const flushNow = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    pushDraft();
+  }, [pushDraft]);
+
+  const setCategory = useCallback(
+    (value: string) => {
+      const next = { ...draftRef.current, category: value };
+      draftRef.current = next;
+      setDraft(next);
+      schedulePush();
+    },
+    [schedulePush]
+  );
+
+  const toggleStyle = useCallback(
+    (slug: string) => {
+      const d = draftRef.current;
+      const nextSet = new Set(d.styleSlugs);
+      if (nextSet.has(slug)) nextSet.delete(slug);
+      else nextSet.add(slug);
+      const next = { ...d, styleSlugs: [...nextSet].sort() };
+      draftRef.current = next;
+      setDraft(next);
+      schedulePush();
+    },
+    [schedulePush]
+  );
+
+  const clearStyles = useCallback(() => {
+    const next = { ...draftRef.current, styleSlugs: [] };
+    draftRef.current = next;
+    setDraft(next);
+    schedulePush();
+  }, [schedulePush]);
+
+  const setPriceBracket = useCallback(
+    (min: number | null, max: number | null) => {
+      const next = {
+        ...draftRef.current,
+        minPrice: min === null ? null : String(min),
+        maxPrice: max === null ? null : String(max),
+      };
+      draftRef.current = next;
+      setDraft(next);
+      schedulePush();
+    },
+    [schedulePush]
+  );
+
+  const value = useMemo(
+    () => ({
+      draft,
+      setCategory,
+      toggleStyle,
+      clearStyles,
+      setPriceBracket,
+      flushNow,
+      isPending,
+    }),
+    [draft, setCategory, toggleStyle, clearStyles, setPriceBracket, flushNow, isPending]
+  );
+
+  return <HomeFilterDraftContext.Provider value={value}>{children}</HomeFilterDraftContext.Provider>;
+}

--- a/src/components/home-filter-panel.tsx
+++ b/src/components/home-filter-panel.tsx
@@ -6,10 +6,23 @@ import { parseStyleSlugsFromSearchParams } from "@/lib/feed-styles";
 import CategoryFilter from "@/components/category-filter";
 import StyleTagFilter from "@/components/style-tag-filter";
 import PriceFilter from "@/components/price-filter";
+import { HomeFilterDraftProvider, useHomeFilterDraft } from "@/components/home-filter-draft";
 
-/** 発見の補助：既定は閉じ、操作は線と文字で軽く */
 export default function HomeFilterPanel() {
   const searchParams = useSearchParams();
+  const searchKey = searchParams.toString();
+
+  return (
+    <HomeFilterDraftProvider key={searchKey}>
+      <HomeFilterPanelInner />
+    </HomeFilterDraftProvider>
+  );
+}
+
+function HomeFilterPanelInner() {
+  const searchParams = useSearchParams();
+  const { flushNow } = useHomeFilterDraft();
+
   const hasActive = useMemo(() => {
     const cat = searchParams.get("category")?.trim();
     const minP = searchParams.get("minPrice");
@@ -33,7 +46,7 @@ export default function HomeFilterPanel() {
       aria-describedby="home-filters-help"
     >
       <p id="home-filters-help" className="sr-only">
-        カテゴリ・スタイル・予算の条件で、部屋の一覧を絞り込めます。
+        カテゴリ・スタイル・予算の条件で、部屋の一覧を絞り込めます。スタイルは続けて選んでも、少し待てばまとめて反映されます。
       </p>
       <div className="home-filter-panel__bar">
         <h2 id="home-filters-heading" className="home-filter-panel__title">
@@ -46,7 +59,13 @@ export default function HomeFilterPanel() {
             aria-expanded={filtersOpen}
             aria-controls="home-filters-body"
             aria-label={filtersOpen ? "絞り込みを閉じる" : "ムードで絞る"}
-            onClick={() => setExpanded((v) => !v)}
+            onClick={() => {
+              setExpanded((v) => {
+                const next = !v;
+                if (v && !next) flushNow();
+                return next;
+              });
+            }}
           >
             <span>{filtersOpen ? "閉じる" : "開く"}</span>
             <svg
@@ -74,7 +93,7 @@ export default function HomeFilterPanel() {
       </div>
       {showCollapsedHint ? (
         <p className="home-filter-panel__collapsed-hint nook-fg-muted mt-1.5 text-[11px] leading-snug sm:mt-2">
-          カテゴリ・スタイル・予算で、好みのムードに近づけられます。
+          カテゴリ・スタイル・予算で、好みのムードに近づけられます。続けて選んでもまとめて反映されます。
         </p>
       ) : null}
       {showFilterBody ? (

--- a/src/components/image-upload.tsx
+++ b/src/components/image-upload.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { getMoodFilter } from "@/lib/image-mood";
+import { BrokenImagePlaceholder } from "@/components/broken-image-placeholder";
 
 /** blob URL は親で Map 管理（子ごとの useMemo + revoke が Strict Mode と競合しやすい） */
 function FilePreviewThumb({
@@ -16,17 +17,30 @@ function FilePreviewThumb({
   index: number;
   onRemove?: (index: number) => void;
 }) {
+  const [failed, setFailed] = useState(false);
+
   return (
     <div
       className="nook-bg-sunken group relative h-[5.25rem] w-[5.25rem] overflow-hidden rounded-[var(--radius-sm)] shadow-[var(--home-tile-shadow)] sm:h-28 sm:w-28"
       role="listitem"
     >
-      <img
-        src={src}
-        alt={`写真 ${index + 1}`}
-        className="h-full w-full object-cover transition-all"
-        style={{ filter: getMoodFilter(mood) }}
-      />
+      {failed ? (
+        <BrokenImagePlaceholder
+          label={`写真 ${index + 1} を表示できません`}
+          mood={mood}
+          compact
+          absoluteFill
+          className="rounded-[var(--radius-sm)]"
+        />
+      ) : (
+        <img
+          src={src}
+          alt={`写真 ${index + 1}`}
+          className="h-full w-full object-cover transition-all"
+          style={{ filter: getMoodFilter(mood) }}
+          onError={() => setFailed(true)}
+        />
+      )}
       {onRemove ? (
         <button
           type="button"
@@ -90,7 +104,7 @@ export default function ImageUpload({ files, onFiles, onRemove, mood }: {
     <div>
       <div
         {...getRootProps()}
-        className={`flex min-h-[min(132px,28dvh)] cursor-pointer flex-col items-center justify-center rounded-[var(--radius-card)] border border-dashed transition duration-150 sm:min-h-[132px] ${isDragActive ? "nook-dropzone-active" : "nook-dropzone-idle"}`}
+        className={`flex min-h-[min(132px,28dvh)] cursor-pointer flex-col items-center justify-center rounded-[var(--radius-card)] border border-dashed transition duration-150 active:scale-[0.99] sm:min-h-[132px] sm:active:scale-100 ${isDragActive ? "nook-dropzone-active" : "nook-dropzone-idle"}`}
         role="button"
         tabIndex={0}
         aria-label="写真を足す"
@@ -112,7 +126,7 @@ export default function ImageUpload({ files, onFiles, onRemove, mood }: {
         <div className="mt-3 flex flex-wrap gap-2" role="list">
           {files.map((_, i) => (
             <FilePreviewThumb
-              key={previewUrls[i]}
+              key={`${previewUrls[i]}-${i}`}
               src={previewUrls[i]!}
               mood={mood}
               index={i}

--- a/src/components/like-button.tsx
+++ b/src/components/like-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import { useSession } from "next-auth/react";
 import { usePathname, useRouter } from "next/navigation";
 import { loginCallbackHref } from "@/lib/login-href";
@@ -13,7 +13,7 @@ export default function LikeButton({ postId, initialLiked, initialCount, size = 
   const pathname = usePathname();
   const [liked, setLiked] = useState(initialLiked);
   const [count, setCount] = useState(initialCount);
-  const [isPending, startTransition] = useTransition();
+  const [pending, setPending] = useState(false);
 
   async function toggleLike(e: React.MouseEvent) {
     e.preventDefault();
@@ -22,25 +22,34 @@ export default function LikeButton({ postId, initialLiked, initialCount, size = 
       router.push(loginCallbackHref(pathname));
       return;
     }
-    setLiked((prev) => !prev);
-    setCount((prev) => (liked ? prev - 1 : prev + 1));
-    startTransition(async () => {
-      try {
-        const res = await fetch("/api/likes", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ postId }),
-        });
-        if (res.ok) {
-          const data = (await res.json()) as { liked?: boolean; likeCount?: number };
-          if (typeof data.liked === "boolean") setLiked(data.liked);
-          if (typeof data.likeCount === "number") setCount(data.likeCount);
-        }
-      } catch {
-        setLiked((prev) => !prev);
-        setCount((prev) => (liked ? prev + 1 : prev - 1));
+    if (pending) return;
+    setPending(true);
+
+    const wasLiked = liked;
+    const prevCount = count;
+    setLiked(!wasLiked);
+    setCount(wasLiked ? Math.max(0, prevCount - 1) : prevCount + 1);
+
+    try {
+      const res = await fetch("/api/likes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ postId }),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { liked?: boolean; likeCount?: number };
+        if (typeof data.liked === "boolean") setLiked(data.liked);
+        if (typeof data.likeCount === "number") setCount(data.likeCount);
+      } else {
+        setLiked(wasLiked);
+        setCount(prevCount);
       }
-    });
+    } catch {
+      setLiked(wasLiked);
+      setCount(prevCount);
+    } finally {
+      setPending(false);
+    }
   }
 
   const iconSize = size === "sm" ? 16 : 20;
@@ -48,9 +57,8 @@ export default function LikeButton({ postId, initialLiked, initialCount, size = 
     <button
       type="button"
       onClick={toggleLike}
-      disabled={isPending}
-      aria-busy={isPending}
-      className={`group inline-flex items-center justify-center gap-1 transition active:scale-[0.96] ${liked ? "nook-like-fg-on" : "nook-fg-muted"} ${size === "sm" ? "min-h-11 min-w-11 rounded-md px-1 py-1 text-xs sm:min-h-9 sm:min-w-9 sm:text-[11px]" : "min-h-11 px-3 py-2 text-xs sm:min-h-0 sm:px-2 sm:py-1.5"}`}
+      aria-busy={pending}
+      className={`group inline-flex items-center justify-center gap-1 transition active:scale-[0.96] ${pending ? "pointer-events-none opacity-80" : ""} ${liked ? "nook-like-fg-on" : "nook-fg-muted"} ${size === "sm" ? "min-h-11 min-w-11 rounded-md px-1 py-1 text-xs sm:min-h-9 sm:min-w-9 sm:text-[11px]" : "min-h-11 px-3 py-2 text-xs sm:min-h-0 sm:px-2 sm:py-1.5"}`}
       aria-label={liked ? "いいねを取り消す" : "いいねする"} aria-pressed={liked}
     >
       <svg width={iconSize} height={iconSize} viewBox="0 0 24 24" aria-hidden>

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -4,9 +4,13 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { NOOK_POST_MODAL_CLOSE_EVENT } from "@/lib/nook-modal";
 
+/** モバイル: シート上部を下にスワイプして閉じる（§5 操作は軽く） */
+const SWIPE_CLOSE_MIN_DY_PX = 72;
+
 export default function Modal({ id, children }: { id: string; children: React.ReactNode }) {
   const checkboxRef = useRef<HTMLInputElement>(null);
   const [open, setOpen] = useState(false);
+  const sheetTouchStartY = useRef<number | null>(null);
 
   const syncCheckbox = useCallback((v: boolean) => {
     const cb = checkboxRef.current;
@@ -30,6 +34,27 @@ export default function Modal({ id, children }: { id: string; children: React.Re
     return () => window.removeEventListener(NOOK_POST_MODAL_CLOSE_EVENT, onProgrammaticClose);
   }, [syncCheckbox]);
 
+  const onSheetSwipeTouchStart = useCallback((e: React.TouchEvent) => {
+    sheetTouchStartY.current = e.touches[0]?.clientY ?? null;
+  }, []);
+
+  const onSheetSwipeTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (sheetTouchStartY.current === null) return;
+      const startY = sheetTouchStartY.current;
+      sheetTouchStartY.current = null;
+      const endY = e.changedTouches[0]?.clientY;
+      if (endY === undefined) return;
+      const dy = endY - startY;
+      if (dy > SWIPE_CLOSE_MIN_DY_PX) handleOpenChange(false);
+    },
+    [handleOpenChange]
+  );
+
+  const onSheetSwipeTouchCancel = useCallback(() => {
+    sheetTouchStartY.current = null;
+  }, []);
+
   return (
     <div className="contents">
       <input
@@ -49,7 +74,6 @@ export default function Modal({ id, children }: { id: string; children: React.Re
           />
           <Dialog.Content
             className="nook-radix-dialog-content nook-modal-dialog-surface nook-post-modal-panel fixed bottom-0 left-0 right-0 z-50 flex max-h-[min(90dvh,720px)] w-full max-w-lg animate-fade-in flex-col overflow-hidden rounded-t-[var(--radius-card)] outline-none focus:outline-none sm:bottom-auto sm:left-1/2 sm:top-1/2 sm:max-h-[90dvh] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-[var(--radius-card)]"
-            aria-labelledby="modal-title"
             onPointerDownOutside={(e) => {
               const t = e.target as HTMLElement | null;
               if (t?.closest?.('[data-radix-popper-content-wrapper]')) {
@@ -64,15 +88,20 @@ export default function Modal({ id, children }: { id: string; children: React.Re
             }}
           >
             <Dialog.Title className="sr-only">写真を載せる</Dialog.Title>
-            <header className="nook-modal-header-surface relative z-20 flex shrink-0 items-center justify-end border-b px-4 py-2.5 sm:px-5 sm:py-3">
-              <span
-                className="nook-modal-drag-indicator pointer-events-none absolute left-1/2 top-3 h-1 w-10 -translate-x-1/2 rounded-full sm:hidden"
+            <header className="nook-modal-header-surface relative z-20 flex min-h-[3.25rem] shrink-0 items-center justify-end border-b px-4 py-2.5 sm:min-h-0 sm:px-5 sm:py-3">
+              <div
+                className="absolute left-0 top-0 z-[1] flex h-[3.25rem] w-[calc(100%-3.5rem)] touch-none items-start justify-center pt-2.5 sm:hidden"
+                onTouchStart={onSheetSwipeTouchStart}
+                onTouchEnd={onSheetSwipeTouchEnd}
+                onTouchCancel={onSheetSwipeTouchCancel}
                 aria-hidden
-              />
+              >
+                <span className="nook-modal-drag-indicator pointer-events-none mt-0.5 h-1 w-10 shrink-0 rounded-full" />
+              </div>
               <Dialog.Close asChild>
                 <button
                   type="button"
-                  className="nook-fg-muted relative flex min-h-[var(--touch)] min-w-[var(--touch)] shrink-0 items-center justify-center rounded-full transition hover:bg-[color-mix(in_srgb,var(--text)_6%,transparent)] active:scale-[0.96] sm:h-9 sm:w-9 sm:min-h-0 sm:min-w-0"
+                  className="nook-fg-muted relative z-10 flex min-h-[var(--touch)] min-w-[var(--touch)] shrink-0 items-center justify-center rounded-full transition hover:bg-[color-mix(in_srgb,var(--text)_6%,transparent)] active:scale-[0.96] sm:h-9 sm:w-9 sm:min-h-0 sm:min-w-0"
                   aria-label="閉じる"
                 >
                   <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden>

--- a/src/components/navbar-client.tsx
+++ b/src/components/navbar-client.tsx
@@ -182,11 +182,15 @@ export default function NavbarClient({
 
         <div className="flex items-center gap-2 sm:hidden">
           <ThemeToggle />
-          {!session && status !== "loading" && (
+          {status === "loading" ? (
+            <span className="nook-bg-sunken flex h-11 w-11 items-center justify-center rounded-full" aria-hidden>
+              <span className="nook-skeleton-pulse h-2 w-2 rounded-full" />
+            </span>
+          ) : !session ? (
             <Link href="/login" className={NAVBAR_LOGIN_LINK_CLASS}>
               ログイン
             </Link>
-          )}
+          ) : null}
           <button
             ref={menuButtonRef}
             type="button"

--- a/src/components/nook-image.tsx
+++ b/src/components/nook-image.tsx
@@ -1,5 +1,9 @@
+"use client";
+
+import { useCallback, useState } from "react";
 import NextImage from "next/image";
 import { getMoodFilter } from "@/lib/image-mood";
+import { BrokenImagePlaceholder } from "@/components/broken-image-placeholder";
 
 type Props = {
   src: string;
@@ -15,7 +19,8 @@ type Props = {
 };
 
 /**
- * Cloudinary・同一オリジン `/uploads` 向けに next/image をラップ
+ * Cloudinary・同一オリジン `/uploads` 向けに next/image をラップ。
+ * 最適化 API の 500・元画像の 404 などでプレースホルダーに切り替える。
  */
 export default function NookImage({
   src,
@@ -28,9 +33,35 @@ export default function NookImage({
   priority,
   mood,
 }: Props) {
-  const filterStyle = { filter: getMoodFilter(mood) };
+  const [failed, setFailed] = useState(false);
+  const onError = useCallback(() => {
+    setFailed(true);
+  }, []);
+
   if (!src) return null;
 
+  if (failed) {
+    if (fill) {
+      return (
+        <BrokenImagePlaceholder
+          label={alt || undefined}
+          mood={mood}
+          absoluteFill
+          className={className}
+        />
+      );
+    }
+    return (
+      <BrokenImagePlaceholder
+        label={alt || undefined}
+        mood={mood}
+        className={className}
+        style={{ width: width ?? 800, height: height ?? 1000 }}
+      />
+    );
+  }
+
+  const filterStyle = { filter: getMoodFilter(mood) };
   if (fill) {
     return (
       <NextImage
@@ -41,6 +72,7 @@ export default function NookImage({
         style={filterStyle}
         sizes={sizes ?? "(max-width: 640px) 50vw, 400px"}
         priority={priority}
+        onError={onError}
       />
     );
   }
@@ -55,6 +87,7 @@ export default function NookImage({
       style={filterStyle}
       sizes={sizes}
       priority={priority}
+      onError={onError}
     />
   );
 }

--- a/src/components/page-back-link.tsx
+++ b/src/components/page-back-link.tsx
@@ -12,6 +12,7 @@ export default function PageBackLink({
   return (
     <Link
       href={href}
+      scroll={false}
       className="nook-fg-muted inline-flex min-h-[var(--touch)] items-center gap-2 text-sm font-medium transition hover:opacity-75 sm:text-xs"
     >
       <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden>

--- a/src/components/post-furniture-list.tsx
+++ b/src/components/post-furniture-list.tsx
@@ -1,4 +1,3 @@
-import NookImage from "@/components/nook-image";
 import WishlistItemButton from "@/components/wishlist-item-button";
 import { getProductUrlMeta } from "@/lib/product-url";
 import {
@@ -17,6 +16,7 @@ type Item = {
   price: number | null;
   currency: string;
   mediaIndex: number;
+  sortOrder: number;
   linkRelation: string;
   linkVerifiedAt: Date | null;
 };
@@ -170,74 +170,16 @@ export default function PostFurnitureList({
 
   if (items.length === 0) return null;
 
-  if (n <= 1) {
-    return (
-      <div className="space-y-3">
-        <p className="nook-fg-muted text-[11px] leading-relaxed">
-          この部屋の写真に写っている（または近い）家具・雑貨です。
-        </p>
-        <ul className="space-y-2" role="list">
-          {items.map((item) => renderItemRow(item, "stagger-item"))}
-        </ul>
-      </div>
-    );
-  }
-
-  const byIdx = new Map<number, Item[]>();
-  for (const item of items) {
-    const idx = clampIdx(item.mediaIndex, n);
-    if (!byIdx.has(idx)) byIdx.set(idx, []);
-    byIdx.get(idx)!.push(item);
-  }
-  const ordered = [...byIdx.keys()].sort((a, b) => a - b);
+  const sorted = [...items].sort((a, b) => {
+    const ai = clampIdx(a.mediaIndex, n);
+    const bi = clampIdx(b.mediaIndex, n);
+    if (ai !== bi) return ai - bi;
+    return a.sortOrder - b.sortOrder;
+  });
 
   return (
-    <div className="space-y-8">
-      <p className="nook-fg-muted text-[11px] leading-relaxed">
-        ギャラリーを切り替えると、右上に{" "}
-        <span className="tabular-nums font-medium text-[var(--text-secondary)]">1 / {n}</span>{" "}
-        のように番号が出ます。この数字と、下の「○ 枚目」は対応しています。
-        <a
-          href="#post-room-gallery"
-          className="ml-1 font-medium text-[var(--text-secondary)] underline decoration-transparent underline-offset-2 transition hover:decoration-[var(--text-faint)]"
-        >
-          写真をもう一度見る
-        </a>
-      </p>
-      {ordered.map((idx) => {
-        const group = byIdx.get(idx)!;
-        const thumb = medias[idx]?.path;
-        const num = idx + 1;
-        return (
-          <section
-            key={idx}
-            id={`post-furniture-photo-${num}`}
-            className="scroll-mt-[calc(var(--nav-height)+0.5rem)]"
-            aria-labelledby={`furniture-photo-heading-${num}`}
-          >
-            <h3 id={`furniture-photo-heading-${num}`} className="nook-overline nook-overline--sentence mb-1">
-              {num} 枚目の家具・雑貨
-            </h3>
-            <p className="nook-fg-faint mb-2 text-[10px] leading-snug">
-              ギャラリーで <span className="tabular-nums font-medium">{num}</span> / {n} と出る写真と同じ組です。
-            </p>
-            {thumb ? (
-              <div className="nook-bg-sunken relative mb-3 aspect-[4/5] w-full max-w-[min(100%,240px)] overflow-hidden rounded-[var(--radius-sm)] border nook-border-hairline sm:max-w-[200px]">
-                <NookImage
-                  src={thumb}
-                  alt={`ギャラリーの${num}枚目の写真（この下の家具・雑貨の参考）`}
-                  fill
-                  className="object-cover"
-                  sizes="(max-width: 639px) 240px, 200px"
-                />
-              </div>
-            ) : null}
-            <ul className="space-y-4" role="list">
-              {group.map((item) => renderItemRow(item, "stagger-item"))}
-            </ul>
-          </section>
-        );
-      })}
-    </div>
+    <ul className="space-y-2" role="list">
+      {sorted.map((item) => renderItemRow(item, "stagger-item"))}
+    </ul>
   );
 }

--- a/src/components/post-gallery.tsx
+++ b/src/components/post-gallery.tsx
@@ -84,6 +84,8 @@ export default function PostGallery({ items }: Props) {
         showBullets={false}
         showIndex={multi}
         indexSeparator=" / "
+        /** ライブラリ既定の <img>（サムネ等）向け。メインスライドは NookImage が別途フォールバック */
+        onErrorImageURL="/empty-state.png"
         renderLeftNav={renderNookGalleryLeftNav}
         renderRightNav={renderNookGalleryRightNav}
       />

--- a/src/components/price-filter.tsx
+++ b/src/components/price-filter.tsx
@@ -1,34 +1,16 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { useTransition } from "react";
 import { FURNITURE_ITEM_PRICE_BRACKETS } from "@/lib/price-brackets";
-import { buildHomeHref } from "@/lib/home-href";
+import { useHomeFilterDraft } from "@/components/home-filter-draft";
 
 export default function PriceFilter() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [isPending, startTransition] = useTransition();
+  const { draft, setPriceBracket, isPending } = useHomeFilterDraft();
 
-  const currentMin = searchParams.get("minPrice");
-  const currentMax = searchParams.get("maxPrice");
-
-  function setPrice(min: number | null, max: number | null) {
-    startTransition(() => {
-      router.push(
-        buildHomeHref(searchParams, (p) => {
-          if (min !== null) p.set("minPrice", min.toString());
-          else p.delete("minPrice");
-          if (max !== null) p.set("maxPrice", max.toString());
-          else p.delete("maxPrice");
-        }),
-        { scroll: false }
-      );
-    });
-  }
+  const currentMin = draft.minPrice;
+  const currentMax = draft.maxPrice;
 
   return (
-    <div className={`price-filter ${isPending ? "pointer-events-none opacity-60" : ""}`} aria-busy={isPending}>
+    <div className="price-filter" aria-busy={isPending}>
       <p className="nook-overline nook-overline--sentence mb-2">価格帯（家具・雑貨1件あたり）</p>
       <p id="price-filter-help" className="sr-only">
         家具・雑貨1件の参考価格の範囲を選ぶと、該当する部屋に絞り込みます。
@@ -40,8 +22,8 @@ export default function PriceFilter() {
         aria-describedby="price-filter-help"
       >
         {FURNITURE_ITEM_PRICE_BRACKETS.map((b) => {
-          const minMatch = b.min === null ? !currentMin : currentMin === b.min.toString();
-          const maxMatch = b.max === null ? !currentMax : currentMax === b.max.toString();
+          const minMatch = b.min === null ? !currentMin : currentMin === String(b.min);
+          const maxMatch = b.max === null ? !currentMax : currentMax === String(b.max);
           const active = minMatch && maxMatch;
 
           return (
@@ -50,7 +32,7 @@ export default function PriceFilter() {
               type="button"
               role="radio"
               aria-checked={active}
-              onClick={() => setPrice(b.min, b.max)}
+              onClick={() => setPriceBracket(b.min, b.max)}
               className="filter-chip shrink-0 active:scale-[0.99] sm:active:scale-100"
             >
               {b.label}

--- a/src/components/profile-settings.tsx
+++ b/src/components/profile-settings.tsx
@@ -65,7 +65,7 @@ export default function ProfileSettings({
         </span>
       </summary>
       <div className="border-t px-4 pb-4 pt-3 nook-border-hairline">
-        <form onSubmit={handleSubmit} className="space-y-3">
+        <form onSubmit={handleSubmit} className="space-y-3" aria-busy={loading}>
           <div>
             <label htmlFor="profile-display-name" className="nook-fg-muted nook-caption-sm font-bold">
               表示名
@@ -122,7 +122,13 @@ export default function ProfileSettings({
               {error}
             </p>
           ) : null}
-          <button type="submit" disabled={loading} className="btn-primary text-sm sm:text-xs disabled:opacity-50">
+          <button
+            type="submit"
+            disabled={loading}
+            aria-busy={loading}
+            aria-label={loading ? "保存しています" : undefined}
+            className="btn-primary text-sm sm:text-xs disabled:opacity-50"
+          >
             {loading ? "保存中…" : "保存"}
           </button>
         </form>

--- a/src/components/same-url-rooms.tsx
+++ b/src/components/same-url-rooms.tsx
@@ -56,9 +56,12 @@ export default async function SameUrlRooms({
 
   return (
     <section className="mt-8 border-t pt-6 nook-border-hairline" aria-labelledby="same-url-heading">
-      <h2 id="same-url-heading" className="nook-section-label mb-3">
-        同じ家具・雑貨のリンクがある部屋
+      <h2 id="same-url-heading" className="nook-section-label mb-1">
+        同じ商品ページの部屋
       </h2>
+      <p className="nook-vision-subline mb-3 !mt-0 max-w-md">
+        同じ家具・雑貨の商品ページURLが載っているほかの部屋です。
+      </p>
       <div className="mt-2 grid grid-cols-3 gap-2 sm:gap-2.5">
         {ranked.map((p) => (
           <div key={p.id} className="stagger-item">

--- a/src/components/share-buttons.tsx
+++ b/src/components/share-buttons.tsx
@@ -5,10 +5,13 @@ import { toast } from "sonner";
 
 export default function ShareButtons({ title, url }: { title: string; url: string }) {
   const [copied, setCopied] = useState(false);
+  const [copying, setCopying] = useState(false);
   const encodedUrl = encodeURIComponent(url);
   const encodedTitle = encodeURIComponent(title);
 
   async function copyLink() {
+    if (copying) return;
+    setCopying(true);
     try {
       await navigator.clipboard.writeText(url);
       setCopied(true);
@@ -16,6 +19,8 @@ export default function ShareButtons({ title, url }: { title: string; url: strin
       window.setTimeout(() => setCopied(false), 2000);
     } catch {
       toast.error("コピーできませんでした");
+    } finally {
+      setCopying(false);
     }
   }
 
@@ -33,7 +38,9 @@ export default function ShareButtons({ title, url }: { title: string; url: strin
       <button
         type="button"
         onClick={copyLink}
-        className={`${btnClass} ${copied ? "nook-fg-secondary" : "nook-fg-muted"}`}
+        aria-busy={copying}
+        disabled={copying}
+        className={`${btnClass} ${copying ? "opacity-70" : ""} ${copied ? "nook-fg-secondary" : "nook-fg-muted"}`}
         aria-label={copied ? "コピーしました" : "この部屋のリンクをコピー"}
       >
         {copied ? (

--- a/src/components/style-tag-filter.tsx
+++ b/src/components/style-tag-filter.tsx
@@ -1,65 +1,23 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { useMemo, useTransition } from "react";
+import { useMemo } from "react";
 import { STYLE_TAGS_PICKER } from "@/lib/style-tags";
-import { parseStyleSlugsFromSearchParams } from "@/lib/feed-styles";
-import { buildHomeHref } from "@/lib/home-href";
+import { useHomeFilterDraft } from "@/components/home-filter-draft";
 
 export default function StyleTagFilter() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [isPending, startTransition] = useTransition();
-  const searchKey = searchParams.toString();
+  const { draft, toggleStyle, clearStyles, isPending } = useHomeFilterDraft();
 
-  const selected = useMemo(() => {
-    const params = new URLSearchParams(searchKey);
-    return new Set(
-      parseStyleSlugsFromSearchParams({
-        styles: params.get("styles") ?? undefined,
-        style: params.get("style") ?? undefined,
-      })
-    );
-  }, [searchKey]);
-
-  function applySlugs(slugs: string[]) {
-    startTransition(() => {
-      router.push(
-        buildHomeHref(searchParams, (p) => {
-          p.delete("style");
-          const sorted = [...new Set(slugs)].filter(Boolean).sort();
-          if (sorted.length === 0) p.delete("styles");
-          else p.set("styles", sorted.join(","));
-        })
-      );
-    });
-  }
-
-  function toggle(slug: string) {
-    const next = new Set(selected);
-    if (next.has(slug)) next.delete(slug);
-    else next.add(slug);
-    applySlugs([...next]);
-  }
-
-  function clearAll() {
-    applySlugs([]);
-  }
+  const selected = useMemo(() => new Set(draft.styleSlugs), [draft.styleSlugs]);
 
   return (
-    <div
-      className={`flex flex-col gap-1 ${isPending ? "pointer-events-none" : ""}`}
-      aria-busy={isPending}
-    >
+    <div className="flex flex-col gap-1" aria-busy={isPending}>
       <p id="style-filter-hint" className="sr-only">
-        スタイルを複数選ぶと、選んだタグがすべて付いた部屋だけが表示されます。
+        スタイルを複数選ぶと、選んだタグがすべて付いた部屋だけが表示されます。続けて選んでも、少し待てばまとめて絞り込みます。
       </p>
       <p className="nook-overline nook-overline--sentence mb-0">スタイル</p>
-      <p className="nook-fg-faint mb-1 nook-caption-sm">
-        複数選ぶと、すべてに合う部屋だけ
-      </p>
+      <p className="nook-fg-faint mb-1 nook-caption-sm">複数選ぶと、すべてに合う部屋だけ</p>
       <div
-        className={`flex gap-0 overflow-x-auto scrollbar-hide ${isPending ? "opacity-60" : ""}`}
+        className="flex gap-0 overflow-x-auto scrollbar-hide"
         role="group"
         aria-label="スタイル"
         aria-describedby="style-filter-hint"
@@ -67,7 +25,7 @@ export default function StyleTagFilter() {
         <button
           type="button"
           aria-pressed={selected.size === 0}
-          onClick={() => clearAll()}
+          onClick={() => clearStyles()}
           className="filter-chip"
         >
           すべて
@@ -79,7 +37,7 @@ export default function StyleTagFilter() {
               key={t.slug}
               type="button"
               aria-pressed={on}
-              onClick={() => toggle(t.slug)}
+              onClick={() => toggleStyle(t.slug)}
               className="filter-chip"
             >
               {t.label}

--- a/src/components/welcome-banner.tsx
+++ b/src/components/welcome-banner.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
+import { useCallback, useState } from "react";
 import { getStyleTagLabel, type StyleTagSlug } from "@/lib/style-tags";
 import { HOME_HERO_IMAGE_SRC } from "@/lib/site-images";
 
@@ -20,6 +21,8 @@ const WELCOME_MOOD_SHORTCUTS: readonly StyleTagSlug[] = [
 /** 未ログイン向けヒーロー：写真主役・短文コピー・ムード近道 */
 export default function WelcomeBanner() {
   const { data: session } = useSession();
+  const [heroFailed, setHeroFailed] = useState(false);
+  const onHeroError = useCallback(() => setHeroFailed(true), []);
 
   if (session) return null;
 
@@ -28,15 +31,20 @@ export default function WelcomeBanner() {
       {/* 背景写真 */}
       <div className="home-hero__media" aria-hidden>
         {/* 表示幅に対して元画像が小さいと拡大で荒れる。差し替え時は幅 1280px 以上を推奨 */}
-        <Image
-          src={HOME_HERO_IMAGE_SRC}
-          alt=""
-          fill
-          className="object-cover"
-          sizes="(max-width: 639px) 100vw, 672px"
-          priority
-          quality={95}
-        />
+        {heroFailed ? (
+          <div className="absolute inset-0 nook-bg-wash" />
+        ) : (
+          <Image
+            src={HOME_HERO_IMAGE_SRC}
+            alt=""
+            fill
+            className="object-cover"
+            sizes="(max-width: 639px) 100vw, 672px"
+            priority
+            quality={95}
+            onError={onHeroError}
+          />
+        )}
         <div className="home-hero__overlay" />
       </div>
 

--- a/src/components/wishlist-item-button.tsx
+++ b/src/components/wishlist-item-button.tsx
@@ -3,7 +3,7 @@
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { loginCallbackHref } from "@/lib/login-href";
-import { useState, useTransition } from "react";
+import { useState } from "react";
 
 type Props = {
   productUrl: string;
@@ -25,7 +25,7 @@ export default function WishlistItemButton({
   const { status } = useSession();
   const router = useRouter();
   const [saved, setSaved] = useState(initialSaved);
-  const [isPending, startTransition] = useTransition();
+  const [pending, setPending] = useState(false);
 
   const isSm = size === "sm";
   const pad = isSm
@@ -39,29 +39,37 @@ export default function WishlistItemButton({
       router.push(loginCallbackHref(`/post/${postId}`));
       return;
     }
-    startTransition(async () => {
-      try {
-        const res = await fetch("/api/wishlist", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ productUrl, name, note, postId }),
-        });
-        const data = await res.json().catch(() => ({}));
-        if (res.ok && typeof data.saved === "boolean") {
-          setSaved(data.saved);
-          router.refresh();
-        }
-      } catch {}
-    });
+    if (pending) return;
+    setPending(true);
+
+    const was = saved;
+    setSaved(!was);
+
+    try {
+      const res = await fetch("/api/wishlist", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ productUrl, name, note, postId }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { saved?: boolean };
+      if (res.ok && typeof data.saved === "boolean") {
+        setSaved(data.saved);
+      } else {
+        setSaved(was);
+      }
+    } catch {
+      setSaved(was);
+    } finally {
+      setPending(false);
+    }
   }
 
   return (
     <button
       type="button"
       onClick={handleClick}
-      disabled={isPending}
-      aria-busy={isPending}
-      className={`shrink-0 rounded-full font-semibold transition active:scale-[0.97] disabled:opacity-50 ${pad}`}
+      aria-busy={pending}
+      className={`shrink-0 rounded-full font-semibold transition active:scale-[0.97] ${pending ? "pointer-events-none opacity-80" : ""} ${pad}`}
       style={
         saved
           ? {
@@ -78,7 +86,7 @@ export default function WishlistItemButton({
       aria-pressed={saved}
       aria-label={saved ? "欲しいから外す" : "欲しいに追加"}
     >
-      {isPending ? "…" : "欲しい"}
+      欲しい
     </button>
   );
 }


### PR DESCRIPTION
## 概要
プロダクトビジョン（発見・発信・写真×購入先・シンプル）に沿った UI/UX・文言・モバイル改善をまとめた PR です。

## 主な変更
- **ホーム絞り込み**: カテゴリ・スタイル・価格をドラフト＋デバウンスでまとめて反映。パネルを閉じると即 flush。
- **モバイル**: タップハイライト、ナビのセッション読み込みスケルトン、投稿モーダルの下スワイプで閉じる、ログインにスマホ用ヒーロー帯。
- **インタラクション**: いいね・保存・フォロー・欲しい・リンクコピーに送信中の `aria-busy` と二重送信防止。
- **文言・a11y**: `PageBackLink` に `scroll={false}`、プロフィール／編集フォーム、重複 id 解消、空状態の短文統一、欲しいリストの外部リンクラベルなど。
- **リファクタ**: 家具ピン画像は `key={imageSrc}` で状態リセット（eslint 対応）、画像プレビューの key、未使用レイアウトクラス削除。
- **新規**: `broken-image-placeholder`、`home-filter-draft`。

## 検証
- `npm run lint` / `tsc --noEmit` 通過

## 備考
ブランチ先頭には既存の Prisma（ブランド・欲しい順）関連コミットが含まれます。

Made with [Cursor](https://cursor.com)